### PR TITLE
refactor ecological index to struct and tests

### DIFF
--- a/packages/hardhat-ts/contracts/GeoNFT.sol
+++ b/packages/hardhat-ts/contracts/GeoNFT.sol
@@ -18,10 +18,14 @@ contract GeoNFT is
 
     Counters.Counter private _tokenIdCounter;
 
+    struct EcologicalIndex {
+        string indexType;
+        int256 indexValue;
+    }
+
     // GeoNFT token properties
     mapping(uint256 => string) private geoJsons; // mapping of tokenId to geoJson
-    mapping(uint256 => uint256) private indexValues; // mapping of tokenId to index value
-    mapping(uint256 => string) private indexTypes; // mapping of tokenId to index type
+    mapping(uint256 => EcologicalIndex) private ecologicalIndexMap;
 
     // solhint-disable-next-line no-empty-blocks, func-visibility
     constructor() ERC721("GEONFT Minter", "GEONFT") {}
@@ -43,8 +47,11 @@ contract GeoNFT is
 
         // default index value to 0 type to area_m2
         // TODO?: Refactor to Struct to unify value and type?
-        indexValues[tokenId] = 0;
-        indexTypes[tokenId] = "area_m2";
+        EcologicalIndex memory ecologicalIndex = EcologicalIndex("area_m2", 0);
+        ecologicalIndexMap[tokenId] = ecologicalIndex;
+
+        // indexValues[tokenId] = 0;
+        // indexTypes[tokenId] = "area_m2";
 
         _safeMint(to, tokenId);
         _setTokenURI(tokenId, uri);
@@ -90,15 +97,18 @@ contract GeoNFT is
         geoJsons[tokenId] = _geoJson;
     }
 
-    function setIndexValue(uint256 tokenId, uint256 _indexValue) external onlyOwner {
-        indexValues[tokenId] = _indexValue;
+    function getEcologicalIndex(uint256 _tokenId) public view returns (EcologicalIndex memory) {
+        return ecologicalIndexMap[_tokenId];
     }
 
-    function setIndexType(uint256 tokenId, string memory indiceType)
-        external
-        onlyOwner
-    {
-        indexTypes[tokenId] = indiceType;
+    function setEcologicalIndex(
+        uint256 _tokenId,
+        string memory _indexType,
+        int256 _indexValue
+    ) external onlyOwner {
+        EcologicalIndex storage ecologicalIndex =  ecologicalIndexMap[_tokenId];
+        ecologicalIndex.indexType = _indexType;
+        ecologicalIndex.indexValue = _indexValue;
     }
 
     // The following functions are overrides required by Solidity.
@@ -134,24 +144,6 @@ contract GeoNFT is
     {
         string memory _geoJson = geoJsons[tokenId];
         return _geoJson;
-    }
-
-    function indexValue(uint256 tokenId)
-        public
-        view
-        returns (uint256)
-    {
-        uint256 _indexValue = indexValues[tokenId];
-        return _indexValue;
-    }
-
-    function indexType(uint256 tokenId)
-        public
-        view
-        returns (string memory)
-    {
-        string memory _indexType = indexTypes[tokenId];
-        return _indexType;
     }
 
     function supportsInterface(bytes4 interfaceId)

--- a/packages/hardhat-ts/test/GeoNFT.test.ts
+++ b/packages/hardhat-ts/test/GeoNFT.test.ts
@@ -99,9 +99,36 @@ describe("geonft", () => {
       expect(await geonft.geoJson(tokenId)).to.be.equal(GEOJSON2.toString());
     });
 
-    it("update index value", async () => {
+    it("update ecological index type", async () => {
       const tokenId = ethers.BigNumber.from(0);
       const tokenURI = "0";
+      const indexTypeDefault = "area_m2";
+      const indexTypeUpdate = "ecologicalindex_percent";
+      const indexValueDefault = 0;
+
+      await expect(
+        geonft.safeMint(other.address, tokenURI, GEOJSON1.toString())
+      )
+        .to.emit(geonft, "Transfer")
+        .withArgs(ZERO_ADDRESS, other.address, tokenId);
+      expect((await geonft.getEcologicalIndex(tokenId)).indexType).to.be.equal(
+        indexTypeDefault
+      );
+
+      await geonft.setEcologicalIndex(
+        tokenId,
+        indexTypeUpdate,
+        indexValueDefault
+      );
+      expect((await geonft.getEcologicalIndex(tokenId)).indexType).to.be.equal(
+        indexTypeUpdate
+      );
+    });
+
+    it("update ecological index value", async () => {
+      const tokenId = ethers.BigNumber.from(0);
+      const tokenURI = "0";
+      const indexTypeDefault = "area_m2";
       const indexValueDefault = 0;
       const indexValueUpdate = 10;
 
@@ -110,27 +137,47 @@ describe("geonft", () => {
       )
         .to.emit(geonft, "Transfer")
         .withArgs(ZERO_ADDRESS, other.address, tokenId);
-      expect(await geonft.indexValue(tokenId)).to.be.equal(indexValueDefault);
+      expect((await geonft.getEcologicalIndex(tokenId)).indexValue).to.be.equal(
+        indexValueDefault
+      );
 
-      await geonft.setIndexValue(tokenId, indexValueUpdate);
-      expect(await geonft.indexValue(tokenId)).to.be.equal(indexValueUpdate);
+      await geonft.setEcologicalIndex(
+        tokenId,
+        indexTypeDefault,
+        indexValueUpdate
+      );
+      expect((await geonft.getEcologicalIndex(tokenId)).indexValue).to.be.equal(
+        indexValueUpdate
+      );
     });
 
-    it("update index type", async () => {
+    it("update ecological index", async () => {
       const tokenId = ethers.BigNumber.from(0);
       const tokenURI = "0";
       const indexTypeDefault = "area_m2";
       const indexTypeUpdate = "ecologicalindex_percent";
+      const indexValueDefault = 0;
+      const indexValueUpdate = 10;
 
       await expect(
         geonft.safeMint(other.address, tokenURI, GEOJSON1.toString())
       )
         .to.emit(geonft, "Transfer")
         .withArgs(ZERO_ADDRESS, other.address, tokenId);
-      expect(await geonft.indexType(tokenId)).to.be.equal(indexTypeDefault);
 
-      await geonft.setIndexType(tokenId, indexTypeUpdate);
-      expect(await geonft.indexType(tokenId)).to.be.equal(indexTypeUpdate);
+      const defaultEcologicalIndex = await geonft.getEcologicalIndex(tokenId);
+      expect(defaultEcologicalIndex.indexType).to.be.equal(indexTypeDefault);
+      expect(defaultEcologicalIndex.indexValue).to.be.equal(indexValueDefault);
+
+      await geonft.setEcologicalIndex(
+        tokenId,
+        indexTypeUpdate,
+        indexValueUpdate
+      );
+
+      const updateEcologicalIndex = await geonft.getEcologicalIndex(tokenId);
+      expect(updateEcologicalIndex.indexType).to.be.equal(indexTypeUpdate);
+      expect(updateEcologicalIndex.indexValue).to.be.equal(indexValueUpdate);
     });
   });
 

--- a/packages/hardhat-ts/test/SDRegistry.test.ts
+++ b/packages/hardhat-ts/test/SDRegistry.test.ts
@@ -91,10 +91,12 @@ describe("registry", () => {
       expect(calculatedArea).to.equal(newArea);
 
       // set area on minted GeoNFT
-      await geoNFT.setIndexValue(tokenId, calculatedArea);
+      await geoNFT.setEcologicalIndex(tokenId, "area_m2", calculatedArea);
 
       // verify area on minted GeoNFT
-      expect(await geoNFT.indexValue(tokenId)).to.equal(calculatedArea);
+      expect((await geoNFT.getEcologicalIndex(tokenId)).indexValue).to.equal(
+        calculatedArea
+      );
     });
   });
 
@@ -171,11 +173,13 @@ describe("registry", () => {
       // get calculated area from AreaCalculation
       const calculatedArea = await areaCalculation.polygonArea(newCoordinates);
       // update area on minted GeoNFT
-      await geoNFT.setIndexValue(tokenId, calculatedArea);
+      await geoNFT.setEcologicalIndex(tokenId, "area_m2", calculatedArea);
       expect(calculatedArea).to.equal(newArea);
 
       // verify area on minted GeoNFT
-      expect(await geoNFT.indexValue(tokenId)).to.equal(calculatedArea);
+      expect((await geoNFT.getEcologicalIndex(tokenId)).indexValue).to.equal(
+        calculatedArea
+      );
 
       // TODO: verify stringified geojson is updated
     });


### PR DESCRIPTION
Refactor ecological index type and value to a struct so and add the to the same mapping. This way, type and value are not separated on different mapping. Now, is possible to update the whole index on one step.